### PR TITLE
Added headers parameter which can be used to pass custom headers

### DIFF
--- a/flagsmith/flagsmith.py
+++ b/flagsmith/flagsmith.py
@@ -17,7 +17,7 @@ class Flagsmith:
 
         :param environment_id: environment key obtained from the Flagsmith UI
         :param api: (optional) api url to override when using self hosted version
-        :param headers: (optional) headers dictionary which will be passed in headers for each api call made to flagsmith
+        :param headers: (optional) dict which will be passed in headers for each api call
         """
         self.environment_id = environment_id
         self.api = api

--- a/flagsmith/flagsmith.py
+++ b/flagsmith/flagsmith.py
@@ -11,18 +11,20 @@ TRAIT_ENDPOINT = "traits/"
 
 
 class Flagsmith:
-    def __init__(self, environment_id, api=SERVER_URL):
+    def __init__(self, environment_id, api=SERVER_URL, headers={}):
         """
         Initialise Flagsmith environment.
 
         :param environment_id: environment key obtained from the Flagsmith UI
         :param api: (optional) api url to override when using self hosted version
+        :param headers: (optional) headers dictionary which will be passed in headers for each api call made to flagsmith
         """
         self.environment_id = environment_id
         self.api = api
         self.flags_endpoint = api + FLAGS_ENDPOINT
         self.identities_endpoint = api + IDENTITY_ENDPOINT
         self.traits_endpoint = api + TRAIT_ENDPOINT
+        self.headers = headers if type(headers) == dict else {}
 
     def get_flags(self, identity=None):
         """
@@ -152,7 +154,7 @@ class Flagsmith:
         }
 
         requests.post(
-            self.traits_endpoint, json=payload, headers=self._generate_header_content()
+            self.traits_endpoint, json=payload, headers=self._generate_header_content(self.headers)
         )
 
     def _get_flags_response(self, feature_name=None, identity=None):
@@ -171,13 +173,13 @@ class Flagsmith:
                 response = requests.get(
                     self.identities_endpoint,
                     params=params,
-                    headers=self._generate_header_content(),
+                    headers=self._generate_header_content(self.headers),
                 )
             else:
                 response = requests.get(
                     self.flags_endpoint,
                     params=params,
-                    headers=self._generate_header_content(),
+                    headers=self._generate_header_content(self.headers),
                 )
 
             if response.status_code == 200:


### PR DESCRIPTION
Added a header parameter to flagsmith. Accepts a dictionary.

We're planning to run flagsmith behind a gateway and the gateway will prevent unauthorised identity / trait manipulation will happen via clients.