### PR TITLE
Improvement/swallow analytics api errors

### DIFF
--- a/flagsmith/analytics.py
+++ b/flagsmith/analytics.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import requests
 from requests_futures.sessions import FuturesSession
@@ -8,7 +8,7 @@ from requests_futures.sessions import FuturesSession
 ANALYTICS_ENDPOINT = "analytics/flags/"
 
 # Used to control how often we send data(in seconds)
-ANALYTICS_TIMER = 10
+DEFAULT_FLUSH_INTERVAL_SECONDS = 10
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +25,7 @@ class AnalyticsProcessor:
         base_api_url: str,
         timeout: int = 3,
         session: FuturesSession = None,
+        flush_interval_seconds: int = DEFAULT_FLUSH_INTERVAL_SECONDS,
     ):
         """
         Initialise the AnalyticsProcessor to handle sending analytics on flag usage to
@@ -37,10 +38,11 @@ class AnalyticsProcessor:
         """
         self.analytics_endpoint = base_api_url + ANALYTICS_ENDPOINT
         self.environment_key = environment_key
-        self._last_flushed = datetime.now()
         self.analytics_data = {}
         self.timeout = timeout
         self.session = session or FuturesSession(max_workers=4)
+        self.flush_interval_seconds = flush_interval_seconds
+        self._next_flush = self._get_next_flush()
 
     def flush(self):
         """
@@ -61,11 +63,15 @@ class AnalyticsProcessor:
                 },
             )
             self.analytics_data.clear()
-            self._last_flushed = datetime.now()
         except requests.ConnectionError as e:
             logger.error("Unable to send flag evaluation analytics to API.", exc_info=e)
 
+        self._next_flush = self._get_next_flush()
+
     def track_feature(self, feature_id: int):
         self.analytics_data[feature_id] = self.analytics_data.get(feature_id, 0) + 1
-        if (datetime.now() - self._last_flushed).seconds > ANALYTICS_TIMER:
+        if datetime.now() > self._next_flush:
             self.flush()
+
+    def _get_next_flush(self):
+        return datetime.now() + timedelta(seconds=self.flush_interval_seconds)

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -5,7 +5,10 @@ from unittest import mock
 
 import requests
 
-from flagsmith.analytics import DEFAULT_FLUSH_INTERVAL_SECONDS, AnalyticsProcessor
+from flagsmith.analytics import (
+    DEFAULT_FLUSH_INTERVAL_SECONDS,
+    AnalyticsProcessor,
+)
 
 
 def test_analytics_processor_track_feature_updates_analytics_data(analytics_processor):

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,8 +1,11 @@
 import json
+import logging
 from datetime import datetime, timedelta
 from unittest import mock
 
-from flagsmith.analytics import ANALYTICS_TIMER
+import requests
+
+from flagsmith.analytics import ANALYTICS_TIMER, AnalyticsProcessor
 
 
 def test_analytics_processor_track_feature_updates_analytics_data(analytics_processor):
@@ -20,38 +23,54 @@ def test_analytics_processor_flush_clears_analytics_data(analytics_processor):
     assert analytics_processor.analytics_data == {}
 
 
-def test_analytics_processor_flush_post_request_data_match_ananlytics_data(
-    analytics_processor,
-):
+def test_analytics_processor_flush_post_request_data_match_analytics_data(mocker):
     # Given
-    with mock.patch("flagsmith.analytics.session") as session:
-        # When
-        analytics_processor.track_feature(1)
-        analytics_processor.track_feature(2)
-        analytics_processor.flush()
+    mock_session = mocker.MagicMock()
+    analytics_processor = AnalyticsProcessor(
+        environment_key="test-key",
+        base_api_url="https://test.api.url/",
+        session=mock_session,
+    )
+
+    # When
+    analytics_processor.track_feature(1)
+    analytics_processor.track_feature(2)
+    analytics_processor.flush()
+
     # Then
-    session.post.assert_called()
-    post_call = session.mock_calls[0]
+    mock_session.post.assert_called_once()
+    post_call = mock_session.post.mock_calls[0]
     assert {"1": 1, "2": 1} == json.loads(post_call[2]["data"])
 
 
-def test_analytics_processor_flush_early_exit_if_analytics_data_is_empty(
-    analytics_processor,
-):
-    with mock.patch("flagsmith.analytics.session") as session:
-        analytics_processor.flush()
+def test_analytics_processor_flush_early_exit_if_analytics_data_is_empty(mocker):
+    # Given
+    mock_session = mocker.MagicMock()
+    analytics_processor = AnalyticsProcessor(
+        environment_key="test-key",
+        base_api_url="https://test.api.url/",
+        session=mock_session,
+    )
+
+    # When
+    analytics_processor.flush()
 
     # Then
-    session.post.assert_not_called()
+    mock_session.post.assert_not_called()
 
 
 def test_analytics_processor_calling_track_feature_calls_flush_when_timer_runs_out(
-    analytics_processor,
+    mocker,
 ):
     # Given
-    with mock.patch("flagsmith.analytics.datetime") as mocked_datetime, mock.patch(
-        "flagsmith.analytics.session"
-    ) as session:
+    mock_session = mocker.MagicMock()
+    analytics_processor = AnalyticsProcessor(
+        environment_key="test-key",
+        base_api_url="https://test.api.url/",
+        session=mock_session,
+    )
+
+    with mock.patch("flagsmith.analytics.datetime") as mocked_datetime:
         # Let's move the time
         mocked_datetime.now.return_value = datetime.now() + timedelta(
             seconds=ANALYTICS_TIMER + 1
@@ -60,4 +79,29 @@ def test_analytics_processor_calling_track_feature_calls_flush_when_timer_runs_o
         analytics_processor.track_feature(1)
 
     # Then
-    session.post.assert_called()
+    mock_session.post.assert_called()
+
+
+def test_flush_swallows_connection_error_and_does_not_clear_analytics_data(
+    mocker, caplog
+):
+    # Given
+    mock_session = mocker.MagicMock()
+    mock_session.post.side_effect = requests.ConnectionError
+
+    analytics_processor = AnalyticsProcessor(
+        environment_key="test-key",
+        base_api_url="https://test.api.url/",
+        session=mock_session,
+    )
+
+    # When
+    analytics_processor.track_feature(1)
+    analytics_processor.flush()
+
+    # Then
+    # No exception raised and analytics processor still has data
+    assert analytics_processor.analytics_data == {1: 1}
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelno == logging.ERROR
+    assert caplog.records[0].msg == "Unable to send flag evaluation analytics to API."

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import requests
 
-from flagsmith.analytics import ANALYTICS_TIMER, AnalyticsProcessor
+from flagsmith.analytics import DEFAULT_FLUSH_INTERVAL_SECONDS, AnalyticsProcessor
 
 
 def test_analytics_processor_track_feature_updates_analytics_data(analytics_processor):
@@ -73,7 +73,7 @@ def test_analytics_processor_calling_track_feature_calls_flush_when_timer_runs_o
     with mock.patch("flagsmith.analytics.datetime") as mocked_datetime:
         # Let's move the time
         mocked_datetime.now.return_value = datetime.now() + timedelta(
-            seconds=ANALYTICS_TIMER + 1
+            seconds=DEFAULT_FLUSH_INTERVAL_SECONDS + 1
         )
         # When
         analytics_processor.track_feature(1)


### PR DESCRIPTION
This PR is on top of the existing PR for the client side evaluation rewrite. As raised by @asadabbasfolio3 , who is writing the .NET client implementation, there was no logic to handle errors when communicating with the API for the purpose of flag evaluation analytics.

This PR seeks to resolve that by swallowing any errors in communication with the analytics API and simply logging an error. Since flag analytics are not critical to the running of the SDK, this seems the most logical approach. The other point to note here is that I have written the logic such that the analytics processor will not flush out its data if the request failed. It will, however, still set the next flush time so that we don't end up spamming the API.