### PR TITLE
Add proxies option to Flagsmith

### DIFF
--- a/flagsmith/flagsmith.py
+++ b/flagsmith/flagsmith.py
@@ -48,6 +48,7 @@ class Flagsmith:
         retries: Retry = None,
         enable_analytics: bool = False,
         default_flag_handler: typing.Callable[[str], DefaultFlag] = None,
+        proxies: typing.Dict[str, str] = None,
     ):
         """
         :param environment_key: The environment key obtained from Flagsmith interface
@@ -66,11 +67,13 @@ class Flagsmith:
         :param default_flag_handler: callable which will be used in the case where
             flags cannot be retrieved from the API or a non existent feature is
             requested
+        :param proxies: as per https://requests.readthedocs.io/en/latest/api/#requests.Session.proxies
         """
         self.session = requests.Session()
         self.session.headers.update(
             **{"X-Environment-Key": environment_key}, **(custom_headers or {})
         )
+        self.session.proxies.update(proxies or {})
         retries = retries or Retry(total=3, backoff_factor=0.1)
 
         self.api_url = api_url if api_url.endswith("/") else f"{api_url}/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flagsmith"
-version = "3.1.0"
+version = "3.2.0"
 description = "Flagsmith Python SDK"
 authors = ["Flagsmith <support@flagsmith.com>"]
 license = "BSD3"

--- a/tests/test_flagsmith.py
+++ b/tests/test_flagsmith.py
@@ -367,3 +367,14 @@ def test_get_identity_segments_with_valid_trait(
 def test_local_evaluation_requires_server_key():
     with pytest.raises(ValueError):
         Flagsmith(environment_key="not-a-server-key", enable_local_evaluation=True)
+
+
+def test_initialise_flagsmith_with_proxies():
+    # Given
+    proxies = {"https": "https://my.proxy.com/proxy-me"}
+
+    # When
+    flagsmith = Flagsmith(environment_key="test-key", proxies=proxies)
+
+    # Then
+    assert flagsmith.session.proxies == proxies


### PR DESCRIPTION
Allows users to define proxies when initialising the Flagsmith client. 