### PR TITLE
Use daemon argument to ensure that polling manager is killed

### DIFF
--- a/flagsmith/flagsmith.py
+++ b/flagsmith/flagsmith.py
@@ -93,6 +93,7 @@ class Flagsmith:
                 EnvironmentDataPollingManager(
                     main=self,
                     refresh_interval_seconds=environment_refresh_interval_seconds,
+                    daemon=True,  # noqa
                 )
             )
             self.environment_data_polling_manager_thread.start()

--- a/flagsmith/polling_manager.py
+++ b/flagsmith/polling_manager.py
@@ -8,9 +8,13 @@ if typing.TYPE_CHECKING:
 
 class EnvironmentDataPollingManager(threading.Thread):
     def __init__(
-        self, main: "Flagsmith", refresh_interval_seconds: typing.Union[int, float] = 10
+        self,
+        *args,
+        main: "Flagsmith",
+        refresh_interval_seconds: typing.Union[int, float] = 10,
+        **kwargs
     ):
-        super(EnvironmentDataPollingManager, self).__init__()
+        super(EnvironmentDataPollingManager, self).__init__(*args, **kwargs)
         self._stop_event = threading.Event()
         self.main = main
         self.refresh_interval_seconds = refresh_interval_seconds

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,7 @@ def local_eval_flagsmith(server_api_key, environment_json, mocker):
 
     yield flagsmith
 
-    flagsmith.__del__()
+    del flagsmith
 
 
 @pytest.fixture()


### PR DESCRIPTION
This adds the daemon argument to the EnvironmentDataPolling manager to ensure that the Flagsmith client is terminated correctly when the main thread is terminated. 

I tested this using the following script: 

```python
import sys

from flagsmith import Flagsmith


if __name__ == "__main__":
    print("Creating Flagsmith client...")
    flagsmith = Flagsmith(
        environment_key="ser.HDwH8inPfcCgrNVgjiur7Z",
        enable_local_evaluation=True,
        environment_refresh_interval_seconds=5,
    )

    print("Exiting the program...")
    sys.exit()
```

This script previously just hung at `sys.exit()` because it wasn't able to kill the environment polling manager thread. Once it's changed to be created as a daemon thread, it kills it correctly and the program shuts down as expected. 

The only downside to this is that the daemon thread is shutdown abruptly meaning that we might see some 'remote connection hung up' type errors in the API but I think this is not a concern. 