### PR TITLE
Implementation of offline mode (single client class)

### DIFF
--- a/flagsmith/flagsmith.py
+++ b/flagsmith/flagsmith.py
@@ -80,6 +80,7 @@ class Flagsmith:
         """
 
         self.offline_mode = offline_mode
+        self.enable_local_evaluation = enable_local_evaluation
         self.offline_handler = offline_handler
         self.default_flag_handler = default_flag_handler
         self._analytics_processor = None
@@ -117,7 +118,7 @@ class Flagsmith:
             self.identities_url = f"{self.api_url}identities/"
             self.environment_url = f"{self.api_url}environment-document/"
 
-            if enable_local_evaluation:
+            if self.enable_local_evaluation:
                 if not environment_key.startswith("ser."):
                     raise ValueError(
                         "In order to use local evaluation, please generate a server key "
@@ -144,7 +145,7 @@ class Flagsmith:
 
         :return: Flags object holding all the flags for the current environment.
         """
-        if self._environment:
+        if (self.offline_mode or self.enable_local_evaluation) and self._environment:
             return self._get_environment_flags_from_document()
         return self._get_environment_flags_from_api()
 
@@ -163,7 +164,7 @@ class Flagsmith:
         :return: Flags object holding all the flags for the given identity.
         """
         traits = traits or {}
-        if self._environment:
+        if (self.offline_mode or self.enable_local_evaluation) and self._environment:
             return self._get_identity_flags_from_document(identifier, traits)
         return self._get_identity_flags_from_api(identifier, traits)
 

--- a/flagsmith/offline_handlers.py
+++ b/flagsmith/offline_handlers.py
@@ -5,13 +5,13 @@ from flag_engine.environments.builders import build_environment_model
 from flag_engine.environments.models import EnvironmentModel
 
 
-class BaseOfflineModeHandler(ABC):
+class BaseOfflineHandler(ABC):
     @abstractmethod
     def get_environment(self) -> EnvironmentModel:
         raise NotImplementedError()
 
 
-class LocalFileHandler(BaseOfflineModeHandler):
+class LocalFileHandler(BaseOfflineHandler):
     def __init__(self, environment_document_path: str):
         with open(environment_document_path) as environment_document:
             self.environment = build_environment_model(

--- a/flagsmith/offline_handlers.py
+++ b/flagsmith/offline_handlers.py
@@ -1,0 +1,22 @@
+import json
+from abc import ABC, abstractmethod
+
+from flag_engine.environments.builders import build_environment_model
+from flag_engine.environments.models import EnvironmentModel
+
+
+class BaseOfflineModeHandler(ABC):
+    @abstractmethod
+    def get_environment(self) -> EnvironmentModel:
+        raise NotImplementedError()
+
+
+class LocalFileHandler(BaseOfflineModeHandler):
+    def __init__(self, environment_document_path: str):
+        with open(environment_document_path) as environment_document:
+            self.environment = build_environment_model(
+                json.loads(environment_document.read())
+            )
+
+    def get_environment(self) -> EnvironmentModel:
+        return self.environment

--- a/tests/test_offline_handlers.py
+++ b/tests/test_offline_handlers.py
@@ -1,0 +1,22 @@
+from unittest.mock import mock_open, patch
+
+from flag_engine.environments.models import EnvironmentModel
+
+from flagsmith.offline_handlers import LocalFileHandler
+
+
+def test_local_file_handler(environment_json):
+    with patch("builtins.open", mock_open(read_data=environment_json)) as mock_file:
+        # Given
+        environment_document_file_path = "/some/path/environment.json"
+        local_file_handler = LocalFileHandler(environment_document_file_path)
+
+        # When
+        environment_model = local_file_handler.get_environment()
+
+        # Then
+        assert isinstance(environment_model, EnvironmentModel)
+        assert (
+            environment_model.api_key == "B62qaMZNwfiqT76p38ggrQ"
+        )  # hard coded from json file
+        mock_file.assert_called_once_with(environment_document_file_path)


### PR DESCRIPTION
Implementation of offline mode repurposing the current flagsmith client. 

Usage would be: 

```python
fs = Flagsmith(offline_mode=True, offline_handler=LocalFileHandler("/some/path/environment.json")
flags = fs.get_environment_flags()
...
```