### PR TITLE
Ensure polling thread is resilient to errors and exceptions

### DIFF
--- a/flagsmith/polling_manager.py
+++ b/flagsmith/polling_manager.py
@@ -1,9 +1,14 @@
+import logging
 import threading
 import time
 import typing
 
+from flagsmith.exceptions import FlagsmithAPIError
+
 if typing.TYPE_CHECKING:
     from flagsmith import Flagsmith
+
+logger = logging.getLogger(__name__)
 
 
 class EnvironmentDataPollingManager(threading.Thread):
@@ -21,7 +26,10 @@ class EnvironmentDataPollingManager(threading.Thread):
 
     def run(self) -> None:
         while not self._stop_event.is_set():
-            self.main.update_environment()
+            try:
+                self.main.update_environment()
+            except FlagsmithAPIError:
+                logging.exception("Failed to update environment")
             time.sleep(self.refresh_interval_seconds)
 
     def stop(self) -> None:

--- a/flagsmith/polling_manager.py
+++ b/flagsmith/polling_manager.py
@@ -3,6 +3,8 @@ import threading
 import time
 import typing
 
+import requests
+
 from flagsmith.exceptions import FlagsmithAPIError
 
 if typing.TYPE_CHECKING:
@@ -28,7 +30,7 @@ class EnvironmentDataPollingManager(threading.Thread):
         while not self._stop_event.is_set():
             try:
                 self.main.update_environment()
-            except FlagsmithAPIError:
+            except (FlagsmithAPIError, requests.RequestException):
                 logging.exception("Failed to update environment")
             time.sleep(self.refresh_interval_seconds)
 

--- a/flagsmith/polling_manager.py
+++ b/flagsmith/polling_manager.py
@@ -31,7 +31,7 @@ class EnvironmentDataPollingManager(threading.Thread):
             try:
                 self.main.update_environment()
             except (FlagsmithAPIError, requests.RequestException):
-                logging.exception("Failed to update environment")
+                logger.exception("Failed to update environment")
             time.sleep(self.refresh_interval_seconds)
 
     def stop(self) -> None:

--- a/tests/test_polling_manager.py
+++ b/tests/test_polling_manager.py
@@ -59,9 +59,7 @@ def test_polling_manager_is_resilient_to_api_errors(mocker, server_api_key):
 def test_polling_manager_is_resilient_to_request_exceptions(mocker, server_api_key):
     # Given
     session_mock = mocker.patch("requests.Session")
-    session_mock.get.return_value = mock.MagicMock(
-        side_effect=requests.RequestException()
-    )
+    session_mock.get.side_effect = requests.RequestException()
     flagsmith = Flagsmith(
         environment_key=server_api_key,
         enable_local_evaluation=True,

--- a/tests/test_polling_manager.py
+++ b/tests/test_polling_manager.py
@@ -43,7 +43,7 @@ def test_polling_manager_calls_update_environment_on_each_refresh():
 def test_polling_manager_is_resilient_to_api_errors(server_api_key):
     with mock.patch("requests.Session") as session_mock:
         # Given
-        session_mock.return_value = mock.MagicMock(get=mock.MagicMock(status_code=500))
+        session_mock.get.return_value = mock.MagicMock(status_code=500)
         flagsmith = Flagsmith(
             environment_key=server_api_key,
             enable_local_evaluation=True,
@@ -59,8 +59,8 @@ def test_polling_manager_is_resilient_to_api_errors(server_api_key):
 def test_polling_manager_is_resilient_to_request_exceptions(server_api_key):
     with mock.patch("requests.Session") as session_mock:
         # Given
-        session_mock.return_value = mock.MagicMock(
-            get=mock.MagicMock(side_effect=requests.RequestException())
+        session_mock.get.return_value = mock.MagicMock(
+            side_effect=requests.RequestException()
         )
         flagsmith = Flagsmith(
             environment_key=server_api_key,

--- a/tests/test_polling_manager.py
+++ b/tests/test_polling_manager.py
@@ -40,35 +40,35 @@ def test_polling_manager_calls_update_environment_on_each_refresh():
     polling_manager.stop()
 
 
-def test_polling_manager_is_resilient_to_api_errors(server_api_key):
-    with mock.patch("requests.Session") as session_mock:
-        # Given
-        session_mock.get.return_value = mock.MagicMock(status_code=500)
-        flagsmith = Flagsmith(
-            environment_key=server_api_key,
-            enable_local_evaluation=True,
-            environment_refresh_interval_seconds=0.1,
-        )
-        polling_manager = flagsmith.environment_data_polling_manager_thread
+def test_polling_manager_is_resilient_to_api_errors(mocker, server_api_key):
+    # Given
+    session_mock = mocker.patch("requests.Session")
+    session_mock.get.return_value = mock.MagicMock(status_code=500)
+    flagsmith = Flagsmith(
+        environment_key=server_api_key,
+        enable_local_evaluation=True,
+        environment_refresh_interval_seconds=0.1,
+    )
+    polling_manager = flagsmith.environment_data_polling_manager_thread
 
-        # Then
-        assert polling_manager.is_alive()
-        polling_manager.stop()
+    # Then
+    assert polling_manager.is_alive()
+    polling_manager.stop()
 
 
-def test_polling_manager_is_resilient_to_request_exceptions(server_api_key):
-    with mock.patch("requests.Session") as session_mock:
-        # Given
-        session_mock.get.return_value = mock.MagicMock(
-            side_effect=requests.RequestException()
-        )
-        flagsmith = Flagsmith(
-            environment_key=server_api_key,
-            enable_local_evaluation=True,
-            environment_refresh_interval_seconds=0.1,
-        )
-        polling_manager = flagsmith.environment_data_polling_manager_thread
+def test_polling_manager_is_resilient_to_request_exceptions(mocker, server_api_key):
+    # Given
+    session_mock = mocker.patch("requests.Session")
+    session_mock.get.return_value = mock.MagicMock(
+        side_effect=requests.RequestException()
+    )
+    flagsmith = Flagsmith(
+        environment_key=server_api_key,
+        enable_local_evaluation=True,
+        environment_refresh_interval_seconds=0.1,
+    )
+    polling_manager = flagsmith.environment_data_polling_manager_thread
 
-        # Then
-        assert polling_manager.is_alive()
-        polling_manager.stop()
+    # Then
+    assert polling_manager.is_alive()
+    polling_manager.stop()


### PR DESCRIPTION
Flagsmith's polling thread is not resilient to API errors. If for whatever reason the API response isn't a 200, [`FlagsmithAPIError` is thrown](https://github.com/Flagsmith/flagsmith-python-client/blob/d334564779f464f5625a90d93611faee56fce1cc/flagsmith/flagsmith.py#L265-L269) and never caught, leaving the SDK running with a dead a polling thread and consequently stale data, even if the source of the error is addressed in the meantime.

Note: There are many ways to bake resiliency into this. This made the most sense to me, but you are welcome to tweak the existing code as you see fit.