### PR TITLE
fix: Set the environment for local evaluation mode on init

### DIFF
--- a/flagsmith/flagsmith.py
+++ b/flagsmith/flagsmith.py
@@ -167,6 +167,9 @@ class Flagsmith:
             self.event_stream_thread.start()
 
         else:
+            # To ensure that the environment is set before allowing subsequent
+            # method calls, update the environment manually.
+            self.update_environment()
             self.environment_data_polling_manager_thread = (
                 EnvironmentDataPollingManager(
                     main=self,


### PR DESCRIPTION
## Changes

This sets up the environment for the first time before booting the update cycle. This avoids a failure where waiting on a network request in one thread allows the primary thread to attempt to get flags before the local cache is set.
