### PR TITLE
Remove pytz and replace usage with core python modules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: mypy
         args: [--strict]
         additional_dependencies:
-          [pydantic, pytest, pytest_mock, types-requests, flagsmith-flag-engine, responses, types-pytz, sseclient-py]
+          [pydantic, pytest, pytest_mock, types-requests, flagsmith-flag-engine, responses, sseclient-py]
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:

--- a/flagsmith/flagsmith.py
+++ b/flagsmith/flagsmith.py
@@ -1,9 +1,8 @@
 import json
 import logging
 import typing
-from datetime import datetime
+from datetime import datetime, timezone
 
-import pytz
 import requests
 from flag_engine import engine
 from flag_engine.environments.models import EnvironmentModel
@@ -212,7 +211,7 @@ class Flagsmith:
             ) from e
 
         if stream_updated_at.tzinfo is None:
-            stream_updated_at = pytz.utc.localize(stream_updated_at)
+            stream_updated_at = stream_updated_at.astimezone(timezone.utc)
 
         if not self._environment:
             raise ValueError(
@@ -220,7 +219,7 @@ class Flagsmith:
             )
         environment_updated_at = self._environment.updated_at
         if environment_updated_at.tzinfo is None:
-            environment_updated_at = pytz.utc.localize(environment_updated_at)
+            environment_updated_at = environment_updated_at.astimezone(timezone.utc)
 
         if stream_updated_at > environment_updated_at:
             self.update_environment()

--- a/poetry.lock
+++ b/poetry.lock
@@ -753,17 +753,6 @@ pytest = ">=5.0"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
-name = "pytz"
-version = "2023.4"
-description = "World timezone definitions, modern and historical"
-optional = false
-python-versions = "*"
-files = [
-    {file = "pytz-2023.4-py2.py3-none-any.whl", hash = "sha256:f90ef520d95e7c46951105338d918664ebfd6f1d995bd7d153127ce90efafa6a"},
-    {file = "pytz-2023.4.tar.gz", hash = "sha256:31d4583c4ed539cd037956140d695e42c033a19e984bfce9964a3f7d59bc2b40"},
-]
-
-[[package]]
 name = "pyyaml"
 version = "6.0.1"
 description = "YAML parser and emitter for Python"
@@ -930,17 +919,6 @@ files = [
 ]
 
 [[package]]
-name = "types-pytz"
-version = "2024.1.0.20240203"
-description = "Typing stubs for pytz"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "types-pytz-2024.1.0.20240203.tar.gz", hash = "sha256:c93751ee20dfc6e054a0148f8f5227b9a00b79c90a4d3c9f464711a73179c89e"},
-    {file = "types_pytz-2024.1.0.20240203-py3-none-any.whl", hash = "sha256:9679eef0365db3af91ef7722c199dbb75ee5c1b67e3c4dd7bfbeb1b8a71c21a3"},
-]
-
-[[package]]
 name = "types-requests"
 version = "2.31.0.20240218"
 description = "Typing stubs for requests"
@@ -1005,4 +983,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4"
-content-hash = "4fe3d98e1321fa3251515d35d8ef180169b23e8143b99cda199afdc6bc84339f"
+content-hash = "555fbec9cbe8ecb76b900ee4958ed71b134f15d4c22d4c9db1c73a9c459306a8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ requests = "^2.27.1"
 requests-futures = "^1.0.0"
 flagsmith-flag-engine = "^5.1.0"
 sseclient-py = "^1.8.0"
-pytz = "^2023.4"
 
 [tool.poetry.group.dev]
 optional = true
@@ -31,7 +30,6 @@ isort = "^5.12.0"
 mypy = "^1.7.1"
 types-requests = "^2.31.0.10"
 pytest-cov = "^4.1.0"
-types-pytz = "^2024.1.0.20240203"
 
 [tool.mypy]
 plugins = ["pydantic.mypy"]


### PR DESCRIPTION
Poetry complained about `pytz` dependency issues while I was trying to install Flagsmith 3.6.0. Started looking through the code and doesn't look like you actually need `pytz`.

Maybe I'm missing something. Hope this makes sense.