### PR TITLE
fix: Offline handler not used as fallback for local evaluation mode during init

### DIFF
--- a/flagsmith/polling_manager.py
+++ b/flagsmith/polling_manager.py
@@ -5,10 +5,6 @@ import threading
 import time
 import typing
 
-import requests
-
-from flagsmith.exceptions import FlagsmithAPIError
-
 if typing.TYPE_CHECKING:
     from flagsmith import Flagsmith
 
@@ -30,10 +26,7 @@ class EnvironmentDataPollingManager(threading.Thread):
 
     def run(self) -> None:
         while not self._stop_event.is_set():
-            try:
-                self.main.update_environment()
-            except (FlagsmithAPIError, requests.RequestException):
-                logger.exception("Failed to update environment")
+            self.main.update_environment()
             time.sleep(self.refresh_interval_seconds)
 
     def stop(self) -> None:

--- a/flagsmith/streaming_manager.py
+++ b/flagsmith/streaming_manager.py
@@ -1,14 +1,9 @@
-import logging
 import threading
 import typing
 from typing import Callable, Generator, Optional, Protocol, cast
 
 import requests
 import sseclient
-
-from flagsmith.exceptions import FlagsmithAPIError
-
-logger = logging.getLogger(__name__)
 
 
 class StreamEvent(Protocol):
@@ -47,9 +42,6 @@ class EventStreamManager(threading.Thread):
 
             except requests.exceptions.ReadTimeout:
                 pass
-
-            except (FlagsmithAPIError, requests.RequestException):
-                logger.exception("Error handling event stream")
 
     def stop(self) -> None:
         self._stop_event.set()

--- a/tests/test_streaming_manager.py
+++ b/tests/test_streaming_manager.py
@@ -36,36 +36,6 @@ def test_stream_manager_handles_timeout(
     streaming_manager.stop()
 
 
-def test_stream_manager_handles_request_exception(
-    mocked_responses: responses.RequestsMock,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    stream_url = (
-        "https://realtime.flagsmith.com/sse/environments/B62qaMZNwfiqT76p38ggrQ/stream"
-    )
-
-    mocked_responses.get(stream_url, body=requests.RequestException())
-    mocked_responses.get(stream_url, body=FlagsmithAPIError())
-
-    streaming_manager = EventStreamManager(
-        stream_url=stream_url,
-        on_event=MagicMock(),
-        daemon=True,
-    )
-
-    streaming_manager.start()
-
-    time.sleep(0.01)
-
-    assert streaming_manager.is_alive()
-
-    streaming_manager.stop()
-
-    for record in caplog.records:
-        assert record.levelname == "ERROR"
-        assert record.message == "Error handling event stream"
-
-
 def test_environment_updates_on_recent_event(
     server_api_key: str, mocker: MockerFixture
 ) -> None:


### PR DESCRIPTION
Closes #99.

Note that as part of this change, the `update_environment()` method is not supposed to produce HTTP-related exceptions now.