### PR TITLE
fix: update conventional commit labelling permissions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,6 +8,7 @@ jobs:
     name: Conventional Commit
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - name: Check PR Conventional Commit title


### PR DESCRIPTION
As per issue [here](https://github.com/bcoe/conventional-release-labels/issues/38)