### PR TITLE
feat: Add utility functions for webhooks

### DIFF
--- a/flagsmith/__init__.py
+++ b/flagsmith/__init__.py
@@ -1,3 +1,4 @@
+from . import webhooks
 from .flagsmith import Flagsmith
 
-__all__ = ("Flagsmith",)
+__all__ = ("Flagsmith", "webhooks")

--- a/flagsmith/webhooks.py
+++ b/flagsmith/webhooks.py
@@ -1,9 +1,10 @@
 import hashlib
 import hmac
+from typing import Union
 
 
 def generate_signature(
-    request_body: str | bytes,
+    request_body: Union[str, bytes],
     shared_secret: str,
 ) -> str:
     """Generates a signature for a webhook request body using HMAC-SHA256.
@@ -25,7 +26,7 @@ def generate_signature(
 
 
 def verify_signature(
-    request_body: str | bytes,
+    request_body: Union[str, bytes],
     received_signature: str,
     shared_secret: str,
 ) -> bool:

--- a/flagsmith/webhooks.py
+++ b/flagsmith/webhooks.py
@@ -1,0 +1,40 @@
+import hashlib
+import hmac
+
+
+def generate_signature(
+    request_body: str | bytes,
+    shared_secret: str,
+) -> str:
+    """Generates a signature for a webhook request body using HMAC-SHA256.
+
+    :param request_body: The raw request body, as string or bytes.
+    :param shared_secret: The shared secret configured for this specific webhook.
+    :return: The hex-encoded signature.
+    """
+    if isinstance(request_body, str):
+        request_body = request_body.encode()
+
+    shared_secret_bytes = shared_secret.encode()
+
+    return hmac.new(
+        key=shared_secret_bytes,
+        msg=request_body,
+        digestmod=hashlib.sha256,
+    ).hexdigest()
+
+
+def verify_signature(
+    request_body: str | bytes,
+    received_signature: str,
+    shared_secret: str,
+) -> bool:
+    """Verifies a webhook's signature to determine if the request was sent by Flagsmith.
+
+    :param request_body: The raw request body, as string or bytes.
+    :param received_signature: The signature as received in the X-Flagsmith-Signature request header.
+    :param shared_secret: The shared secret configured for this specific webhook.
+    :return: True if the signature is valid, False otherwise.
+    """
+    expected_signature = generate_signature(request_body, shared_secret)
+    return hmac.compare_digest(expected_signature, received_signature)

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,0 +1,50 @@
+import json
+
+from flagsmith.webhooks import generate_signature, verify_signature
+
+
+def test_generate_signature():
+    # Given
+    request_body = json.dumps({"data": {"foo": 123}})
+    shared_secret = "shh"
+
+    # When
+    signature = generate_signature(request_body, shared_secret)
+
+    # Then
+    assert isinstance(signature, str)
+    assert len(signature) == 64  # SHA-256 hex digest is 64 characters
+
+
+def test_verify_signature_valid():
+    # Given
+    request_body = json.dumps({"data": {"foo": 123}})
+    shared_secret = "shh"
+
+    # When
+    signature = generate_signature(request_body, shared_secret)
+
+    # Then
+    assert verify_signature(
+        request_body=request_body,
+        received_signature=signature,
+        shared_secret=shared_secret,
+    )
+    # Test with bytes instead of str
+    assert verify_signature(
+        request_body=request_body.encode(),
+        received_signature=signature,
+        shared_secret=shared_secret,
+    )
+
+
+def test_verify_signature_invalid():
+    # Given
+    request_body = json.dumps({"event": "flag_updated", "data": {"id": 123}})
+
+    # Then
+    assert not verify_signature(
+        request_body=request_body,
+        received_signature="bad",
+        shared_secret="?",
+    )

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -3,7 +3,7 @@ import json
 from flagsmith.webhooks import generate_signature, verify_signature
 
 
-def test_generate_signature():
+def test_generate_signature() -> None:
     # Given
     request_body = json.dumps({"data": {"foo": 123}})
     shared_secret = "shh"
@@ -16,7 +16,7 @@ def test_generate_signature():
     assert len(signature) == 64  # SHA-256 hex digest is 64 characters
 
 
-def test_verify_signature_valid():
+def test_verify_signature_valid() -> None:
     # Given
     request_body = json.dumps({"data": {"foo": 123}})
     shared_secret = "shh"
@@ -38,7 +38,7 @@ def test_verify_signature_valid():
     )
 
 
-def test_verify_signature_invalid():
+def test_verify_signature_invalid() -> None:
     # Given
     request_body = json.dumps({"event": "flag_updated", "data": {"id": 123}})
 


### PR DESCRIPTION
Instead of having [code snippets in our docs](https://docs.flagsmith.com/system-administration/webhooks#validating-signature) that describe how to validate webhook signatures, we should ship the code directly as part of all server-side SDKs.

There's a potential concern on whether this code belongs as part of this SDK, or if it should belong in a different package or not at all. I believe it does, for several reasons:

* We're not adding dependencies to this package or meaningfully increasing the package size.
* If package size was a concern, it would mainly be for client-side applications and not server-side. If this does become a problem, we can have separate artifacts for client-side and server-side applications.
* We're using a separate namespace from everything else.
* There's almost no benefit (minus package size) to having to publish a new library just for this type of code.

As an example, I like Auth0's approach for this, where they publish a single dependency with different namespaces for the authentication and management components (analogous to our flags APIs and admin APIs): https://github.com/auth0/node-auth0?tab=readme-ov-file#configure-the-sdk 