### PR TITLE
ci: replace publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   tag_name: ${{ github.event.release.tag_name || github.ref_name }}
-  artifact-name: flagsmith-common-${{ github.event.release.tag_name || github.ref_name }}
+  artifact-name: flagsmith-python-client-${{ github.event.release.tag_name || github.ref_name }}
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,8 @@ jobs:
           fetch-depth: 0
 
       - name: Build and publish to pypi
-        uses: JRubics/poetry-publish@v1.10
+        uses: JRubics/poetry-publish@v2
         with:
           pypi_token: ${{ secrets.PYPI_API_TOKEN }}
-          ignore_dev_requirements: 'yes'
           build_format: 'sdist'
+          poetry_install_options: '--without dev'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,24 +1,52 @@
-name: Publish PyPI Package
+name: Publish to PyPI
 
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+env:
+  tag_name: ${{ github.event.release.tag_name || github.ref_name }}
+  artifact-name: flagsmith-common-${{ github.event.release.tag_name || github.ref_name }}
 
 jobs:
-  package:
+  build:
     runs-on: ubuntu-latest
-    name: Publish Pypi Package
 
     steps:
-      - name: Cloning repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
 
-      - name: Build and publish to pypi
-        uses: JRubics/poetry-publish@v2
+      - uses: actions/setup-python@v4
         with:
-          pypi_token: ${{ secrets.PYPI_API_TOKEN }}
-          build_format: 'sdist'
-          poetry_install_options: '--without dev'
+          python-version: 3.12
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Build Package
+        run: poetry build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.artifact-name }}
+          path: dist/
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.tag_name }}
+          files: dist/*
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+
+    permissions:
+      id-token: write # for pypa/gh-action-pypi-publish to authenticate with PyPI
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.artifact-name }}
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Replaces third party publishing flow with the official pypa action (copied from [here](https://github.com/Flagsmith/flagsmith-common/blob/main/.github/workflows/publish.yml)). 

I have configured the auth on the pypi side as per the following screenshot. 

<img width="701" alt="image" src="https://github.com/user-attachments/assets/1fad6b88-650a-4c84-8d75-2c6c288f8445" />
