### PR TITLE
fix: Fix HTTP requests not timing out

### DIFF
--- a/flagsmith/flagsmith.py
+++ b/flagsmith/flagsmith.py
@@ -49,7 +49,7 @@ class Flagsmith:
         api_url: typing.Optional[str] = None,
         realtime_api_url: typing.Optional[str] = None,
         custom_headers: typing.Optional[typing.Dict[str, typing.Any]] = None,
-        request_timeout_seconds: typing.Optional[int] = None,
+        request_timeout_seconds: typing.Optional[int] = 10,
         enable_local_evaluation: bool = False,
         environment_refresh_interval_seconds: typing.Union[int, float] = 60,
         retries: typing.Optional[Retry] = None,


### PR DESCRIPTION
Fixes #115.

## What is the problem

[This](https://github.com/Flagsmith/flagsmith-python-client/issues/115): the default HTTP timeout (10 seconds) isn't used, leading to requests — under timeout-y circumstances — hanging for longer than stated in the docs.


## How it was fixed

Respecting the default timeout.


## How it was tested

Unit tests.