### PR TITLE
chore(actions): move project id to a var in issue workflow

### DIFF
--- a/.github/workflows/add-issues-to-engineering-project.yml
+++ b/.github/workflows/add-issues-to-engineering-project.yml
@@ -14,12 +14,11 @@ jobs:
           github-token: ${{ secrets.GH_TOKEN_ADD_TO_ENG_PROJECT }}
           script: |
             const issueId = context.payload.issue.node_id;
-            const projectId = '22';
 
             const mutation = `
               mutation {
                 addProjectV2ItemById(input: {
-                  projectId: "${projectId}",
+                  projectId: "${{ vars.ENGINEERING_PROJECT_ID }}",
                   contentId: "${issueId}"
                 }) {
                   item {


### PR DESCRIPTION
The previously used identifier '22' was incorrect, but should have been a var either way. I've created the var at the organisation level to reuse across repos if needed. 