### PR TITLE
feat: Support SDK metrics

### DIFF
--- a/flagsmith/__init__.py
+++ b/flagsmith/__init__.py
@@ -1,4 +1,5 @@
-from . import webhooks
-from .flagsmith import Flagsmith
+from flagsmith import webhooks
+from flagsmith.flagsmith import Flagsmith
+from flagsmith.version import __version__
 
-__all__ = ("Flagsmith", "webhooks")
+__all__ = ("Flagsmith", "webhooks", "__version__")

--- a/flagsmith/flagsmith.py
+++ b/flagsmith/flagsmith.py
@@ -20,7 +20,12 @@ from flagsmith.models import DefaultFlag, Flags, Segment
 from flagsmith.offline_handlers import BaseOfflineHandler
 from flagsmith.polling_manager import EnvironmentDataPollingManager
 from flagsmith.streaming_manager import EventStreamManager, StreamEvent
-from flagsmith.types import ApplicationMetadata, JsonType, TraitConfig, TraitMapping
+from flagsmith.types import (
+    ApplicationMetadata,
+    JsonType,
+    TraitConfig,
+    TraitMapping,
+)
 from flagsmith.utils.identities import generate_identity_data
 from flagsmith.version import __version__
 

--- a/flagsmith/types.py
+++ b/flagsmith/types.py
@@ -1,7 +1,7 @@
 import typing
 
 from flag_engine.identities.traits.types import TraitValue
-from typing_extensions import TypeAlias, NotRequired
+from typing_extensions import NotRequired, TypeAlias
 
 _JsonScalarType: TypeAlias = typing.Union[
     int,

--- a/flagsmith/types.py
+++ b/flagsmith/types.py
@@ -1,7 +1,7 @@
 import typing
 
 from flag_engine.identities.traits.types import TraitValue
-from typing_extensions import TypeAlias
+from typing_extensions import TypeAlias, NotRequired
 
 _JsonScalarType: TypeAlias = typing.Union[
     int,
@@ -23,3 +23,8 @@ class TraitConfig(typing.TypedDict):
 
 
 TraitMapping: TypeAlias = typing.Mapping[str, typing.Union[TraitValue, TraitConfig]]
+
+
+class ApplicationMetadata(typing.TypedDict):
+    name: NotRequired[str]
+    version: NotRequired[str]

--- a/flagsmith/version.py
+++ b/flagsmith/version.py
@@ -1,0 +1,3 @@
+from importlib.metadata import version
+
+__version__ = version("flagsmith")

--- a/tests/test_flagsmith.py
+++ b/tests/test_flagsmith.py
@@ -11,7 +11,7 @@ from flag_engine.features.models import FeatureModel, FeatureStateModel
 from pytest_mock import MockerFixture
 from responses import matchers
 
-from flagsmith import Flagsmith
+from flagsmith import Flagsmith, __version__
 from flagsmith.exceptions import (
     FlagsmithAPIError,
     FlagsmithFeatureDoesNotExistError,
@@ -717,3 +717,96 @@ def test_custom_feature_error_raised_when_invalid_feature(
     with pytest.raises(FlagsmithFeatureDoesNotExistError):
         # When
         flags.is_feature_enabled("non-existing-feature")
+
+
+@pytest.fixture
+def default_headers() -> typing.Dict[str, str]:
+    return {
+        "User-Agent": f"flagsmith-python-client/{__version__} python-requests/2.32.4",
+        "Accept-Encoding": "gzip, deflate",
+        "Accept": "*/*",
+        "Connection": "keep-alive",
+    }
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected_headers",
+    [
+        (
+            {
+                "environment_key": "test-key",
+                "application_metadata": {"name": "test-app", "version": "1.0.0"},
+            },
+            {
+                "Flagsmith-Application-Name": "test-app",
+                "Flagsmith-Application-Version": "1.0.0",
+                "X-Environment-Key": "test-key",
+            },
+        ),
+        (
+            {
+                "environment_key": "test-key",
+                "application_metadata": {"name": "test-app"},
+            },
+            {
+                "Flagsmith-Application-Name": "test-app",
+                "X-Environment-Key": "test-key",
+            },
+        ),
+        (
+            {
+                "environment_key": "test-key",
+                "application_metadata": {"version": "1.0.0"},
+            },
+            {
+                "Flagsmith-Application-Version": "1.0.0",
+                "X-Environment-Key": "test-key",
+            },
+        ),
+        (
+            {
+                "environment_key": "test-key",
+                "application_metadata": {"version": "1.0.0"},
+                "custom_headers": {"X-Custom-Header": "CustomValue"},
+            },
+            {
+                "Flagsmith-Application-Version": "1.0.0",
+                "X-Environment-Key": "test-key",
+                "X-Custom-Header": "CustomValue",
+            },
+        ),
+        (
+            {
+                "environment_key": "test-key",
+                "application_metadata": None,
+                "custom_headers": {"X-Custom-Header": "CustomValue"},
+            },
+            {
+                "X-Environment-Key": "test-key",
+                "X-Custom-Header": "CustomValue",
+            },
+        ),
+        (
+            {"environment_key": "test-key"},
+            {
+                "X-Environment-Key": "test-key",
+            },
+        ),
+    ],
+)
+@responses.activate()
+def test_flagsmith__init__expected_headers_sent(
+    default_headers: typing.Dict[str, str],
+    kwargs: typing.Dict[str, typing.Any],
+    expected_headers: typing.Dict[str, str],
+) -> None:
+    # Given
+    flagsmith = Flagsmith(**kwargs)
+    responses.add(method="GET", url=flagsmith.environment_flags_url, body="{}")
+
+    # When
+    flagsmith.get_environment_flags()
+
+    # Then
+    headers = responses.calls[0].request.headers
+    assert headers == {**default_headers, **expected_headers}


### PR DESCRIPTION
- Adds custom `User-Agent` header value to include the SDK name and version
- Adds support for optional client application metadata when initialising the Flagsmith client