### PR TITLE
chore: replaced-get-identity-segments-with-get-context-segments

### DIFF
--- a/flagsmith/flagsmith.py
+++ b/flagsmith/flagsmith.py
@@ -6,12 +6,12 @@ from datetime import timezone
 import pydantic
 import requests
 from flag_engine import engine
+from flag_engine.context.mappers import map_environment_identity_to_context
 from flag_engine.environments.models import EnvironmentModel
 from flag_engine.identities.models import IdentityModel
 from flag_engine.identities.traits.models import TraitModel
 from flag_engine.identities.traits.types import TraitValue
 from flag_engine.segments.evaluator import get_context_segments
-from flag_engine.context.mappers import map_environment_identity_to_context
 from requests.adapters import HTTPAdapter
 from requests.utils import default_user_agent
 from urllib3 import Retry


### PR DESCRIPTION
We have removed the function get_identity_segments from the engine API. This issue covers the update of the `get_identity_segments` method to use the `get_context_segments` function.