### PR TITLE
fix: restart local-eval polling thread after fork (#77)

### DIFF
--- a/flagsmith/flagsmith.py
+++ b/flagsmith/flagsmith.py
@@ -235,7 +235,6 @@ class Flagsmith:
                 EnvironmentDataPollingManager(
                     main=self,
                     refresh_interval_seconds=self.environment_refresh_interval_seconds,
-                    daemon=True,
                 )
             )
 

--- a/flagsmith/polling_manager.py
+++ b/flagsmith/polling_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import threading
 import time
 import typing
@@ -11,26 +12,64 @@ if typing.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class EnvironmentDataPollingManager(threading.Thread):
+class EnvironmentDataPollingManager:
+    """Owns the worker thread that periodically refreshes the local
+    evaluation environment document.
+
+    Composes (rather than extends) :class:`threading.Thread` so the
+    worker can be replaced — most importantly after :func:`os.fork`,
+    where threads do not survive into the child. We register an at-fork
+    hook so a forked worker (gunicorn, uwsgi, multiprocessing) gets a
+    freshly-started polling thread for its own PID. See issue #77.
+    """
+
     def __init__(
         self,
-        *args: typing.Any,
+        *,
         main: Flagsmith,
         refresh_interval_seconds: typing.Union[int, float] = 10,
-        **kwargs: typing.Any,
-    ):
-        super(EnvironmentDataPollingManager, self).__init__(*args, **kwargs)
+    ) -> None:
+        self._main = main
+        self._refresh_interval_seconds = refresh_interval_seconds
         self._stop_event = threading.Event()
-        self.main = main
-        self.refresh_interval_seconds = refresh_interval_seconds
+        self._thread = self._build_thread()
+        self._at_fork_registered = False
 
-    def run(self) -> None:
+    def _build_thread(self) -> threading.Thread:
+        return threading.Thread(target=self._run, daemon=True)
+
+    def _run(self) -> None:
         while not self._stop_event.is_set():
-            self.main.update_environment()
-            time.sleep(self.refresh_interval_seconds)
+            self._main.update_environment()
+            time.sleep(self._refresh_interval_seconds)
+
+    def start(self) -> None:
+        self._thread.start()
+        if not self._at_fork_registered and hasattr(os, "register_at_fork"):
+            os.register_at_fork(after_in_child=self._restart_after_fork)
+            self._at_fork_registered = True
+
+    def _restart_after_fork(self) -> None:
+        if self._thread.is_alive():
+            return
+        # Sockets in the parent's connection pool are inherited as
+        # shared FDs across fork; reusing them would interleave bytes
+        # between processes. Drop them so the new thread opens fresh.
+        if session := getattr(self._main, "session", None):
+            session.close()
+        self._stop_event = threading.Event()
+        self._thread = self._build_thread()
+        self._thread.start()
 
     def stop(self) -> None:
         self._stop_event.set()
+
+    def is_alive(self) -> bool:
+        return self._thread.is_alive()
+
+    @property
+    def ident(self) -> typing.Optional[int]:
+        return self._thread.ident
 
     def __del__(self) -> None:
         self._stop_event.set()

--- a/poetry.lock
+++ b/poetry.lock
@@ -385,6 +385,106 @@ iregexp-check = ">=0.1.4"
 regex = "*"
 
 [[package]]
+name = "markupsafe"
+version = "3.0.3"
+description = "Safely add untrusted strings to HTML/XML markup."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+markers = "python_version >= \"3.10\""
+files = [
+    {file = "markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559"},
+    {file = "markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419"},
+    {file = "markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695"},
+    {file = "markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591"},
+    {file = "markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c"},
+    {file = "markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f"},
+    {file = "markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6"},
+    {file = "markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1"},
+    {file = "markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa"},
+    {file = "markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8"},
+    {file = "markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1"},
+    {file = "markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad"},
+    {file = "markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a"},
+    {file = "markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50"},
+    {file = "markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf"},
+    {file = "markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f"},
+    {file = "markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a"},
+    {file = "markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115"},
+    {file = "markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a"},
+    {file = "markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19"},
+    {file = "markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01"},
+    {file = "markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c"},
+    {file = "markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e"},
+    {file = "markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce"},
+    {file = "markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d"},
+    {file = "markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d"},
+    {file = "markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a"},
+    {file = "markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b"},
+    {file = "markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f"},
+    {file = "markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b"},
+    {file = "markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d"},
+    {file = "markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c"},
+    {file = "markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f"},
+    {file = "markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795"},
+    {file = "markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219"},
+    {file = "markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6"},
+    {file = "markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676"},
+    {file = "markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9"},
+    {file = "markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1"},
+    {file = "markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc"},
+    {file = "markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12"},
+    {file = "markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed"},
+    {file = "markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5"},
+    {file = "markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218"},
+    {file = "markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287"},
+    {file = "markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe"},
+    {file = "markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026"},
+    {file = "markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737"},
+    {file = "markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97"},
+    {file = "markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d"},
+    {file = "markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda"},
+    {file = "markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf"},
+    {file = "markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe"},
+    {file = "markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9"},
+    {file = "markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581"},
+    {file = "markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9"},
+    {file = "markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa"},
+    {file = "markupsafe-3.0.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:15d939a21d546304880945ca1ecb8a039db6b4dc49b2c5a400387cdae6a62e26"},
+    {file = "markupsafe-3.0.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f71a396b3bf33ecaa1626c255855702aca4d3d9fea5e051b41ac59a9c1c41edc"},
+    {file = "markupsafe-3.0.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f4b68347f8c5eab4a13419215bdfd7f8c9b19f2b25520968adfad23eb0ce60c"},
+    {file = "markupsafe-3.0.3-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8fc20152abba6b83724d7ff268c249fa196d8259ff481f3b1476383f8f24e42"},
+    {file = "markupsafe-3.0.3-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:949b8d66bc381ee8b007cd945914c721d9aba8e27f71959d750a46f7c282b20b"},
+    {file = "markupsafe-3.0.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:3537e01efc9d4dccdf77221fb1cb3b8e1a38d5428920e0657ce299b20324d758"},
+    {file = "markupsafe-3.0.3-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:591ae9f2a647529ca990bc681daebdd52c8791ff06c2bfa05b65163e28102ef2"},
+    {file = "markupsafe-3.0.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a320721ab5a1aba0a233739394eb907f8c8da5c98c9181d1161e77a0c8e36f2d"},
+    {file = "markupsafe-3.0.3-cp39-cp39-win32.whl", hash = "sha256:df2449253ef108a379b8b5d6b43f4b1a8e81a061d6537becd5582fba5f9196d7"},
+    {file = "markupsafe-3.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:7c3fb7d25180895632e5d3148dbdc29ea38ccb7fd210aa27acbd1201a1902c6e"},
+    {file = "markupsafe-3.0.3-cp39-cp39-win_arm64.whl", hash = "sha256:38664109c14ffc9e7437e86b4dceb442b0096dfe3541d7864d9cbe1da4cf36c8"},
+    {file = "markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698"},
+]
+
+[[package]]
 name = "mypy"
 version = "1.17.1"
 description = "Optional static typing for Python"
@@ -598,6 +698,22 @@ pytest = ">=4.6"
 
 [package.extras]
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
+
+[[package]]
+name = "pytest-httpserver"
+version = "1.1.5"
+description = "pytest-httpserver is a httpserver for pytest"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+markers = "python_version >= \"3.10\""
+files = [
+    {file = "pytest_httpserver-1.1.5-py3-none-any.whl", hash = "sha256:ee83feb587ab652c0c6729598db2820e9048233bac8df756818b7845a1621d0a"},
+    {file = "pytest_httpserver-1.1.5.tar.gz", hash = "sha256:dc3d82e1fe00e491829d8939c549bf4bd9b39a260f87113c619b9d517c2f8ff1"},
+]
+
+[package.dependencies]
+Werkzeug = ">=2.0.0"
 
 [[package]]
 name = "pytest-mock"
@@ -974,7 +1090,26 @@ typing-extensions = {version = ">=4.13.2", markers = "python_version < \"3.11\""
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8) ; platform_python_implementation == \"PyPy\" or platform_python_implementation == \"GraalVM\" or platform_python_implementation == \"CPython\" and sys_platform == \"win32\" and python_version >= \"3.13\"", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10) ; platform_python_implementation == \"CPython\""]
 
+[[package]]
+name = "werkzeug"
+version = "3.1.8"
+description = "The comprehensive WSGI web application library."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+markers = "python_version >= \"3.10\""
+files = [
+    {file = "werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50"},
+    {file = "werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44"},
+]
+
+[package.dependencies]
+markupsafe = ">=2.1.1"
+
+[package.extras]
+watchdog = ["watchdog (>=2.3)"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4"
-content-hash = "e91aea422e521889c402d406d22ac7541dea465a76097c131135c7ec046f1c9d"
+content-hash = "fd0a98185f8d9502a1152cf469e6cc6f3240704f5fb90076b197a664c7f21758"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,12 @@ pytest-httpserver = {version = "^1.1.0", python = ">=3.10,<4"}
 [tool.mypy]
 exclude = ["example/*"]
 
+[[tool.mypy.overrides]]
+# pytest-httpserver requires python>=3.10, so it is not installed in
+# the 3.9 dev environment and mypy cannot find its stubs there.
+module = "pytest_httpserver"
+ignore_missing_imports = true
+
 [tool.black]
 target-version = ["py39"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ pre-commit = { version = "^4.2.0", python = ">=3.9,<4" }
 responses = "^0.24.1"
 types-requests = "^2.32"
 pyfakefs = "^5.9.2"
+pytest-httpserver = {version = "^1.1.0", python = ">=3.10,<4"}
 
 [tool.mypy]
 exclude = ["example/*"]

--- a/tests/test_polling_manager.py
+++ b/tests/test_polling_manager.py
@@ -1,8 +1,13 @@
+import json
+import multiprocessing
 import time
+from pathlib import Path
 from unittest import mock
 
+import pytest
 import requests
 import responses
+from pytest_httpserver import HTTPServer
 from pytest_mock import MockerFixture
 
 from flagsmith import Flagsmith
@@ -91,3 +96,57 @@ def test_polling_manager_is_resilient_to_request_exceptions(
     # Then
     assert polling_manager.is_alive()
     polling_manager.stop()
+
+
+@pytest.fixture
+def api_url(
+    httpserver: HTTPServer,
+    request: pytest.FixtureRequest,
+) -> str:
+    """A local HTTP server impersonating the Flagsmith environment-document API."""
+    body = (request.path.parent / "data/environment.json").read_bytes()
+    httpserver.expect_request("/api/v1/environment-document/").respond_with_data(
+        body, content_type="application/json"
+    )
+    return httpserver.url_for("/api/v1/")
+
+
+@pytest.mark.skipif(
+    "fork" not in multiprocessing.get_all_start_methods(),
+    reason="fork() is unavailable on this platform",
+)
+def test_polling_manager_keeps_polling_after_fork(api_url: str, tmp_path: Path) -> None:
+    # Given a flagsmith client polling against a local HTTP server.
+    flagsmith = Flagsmith(
+        environment_key="ser.dummy",
+        api_url=api_url,
+        enable_local_evaluation=True,
+        environment_refresh_interval_seconds=0.1,
+    )
+    parent_ident = flagsmith.environment_data_polling_manager_thread.ident
+
+    def _record_polling_state_in_child(flagsmith: Flagsmith, result_path: Path) -> None:
+        # Give the child a chance to poll.
+        time.sleep(0.1)
+        polling = flagsmith.environment_data_polling_manager_thread
+        result_path.write_text(
+            json.dumps({"is_alive": polling.is_alive(), "ident": polling.ident})
+        )
+
+    # Give the parent a chance to poll.
+    time.sleep(0.1)
+    result_path = tmp_path / "child_result.json"
+
+    # When the process forks (mimicking a gunicorn pre-fork worker).
+    proc = multiprocessing.get_context("fork").Process(
+        target=_record_polling_state_in_child, args=(flagsmith, result_path)
+    )
+    proc.start()
+    proc.join()
+
+    # Then the polling thread is alive in the child, and it's a fresh
+    # thread rather than the parent's (dead) one.
+    result = json.loads(result_path.read_text())
+    assert result["is_alive"], "polling thread did not survive fork()"
+    assert result["ident"] != parent_ident
+    flagsmith.environment_data_polling_manager_thread.stop()

--- a/tests/test_polling_manager.py
+++ b/tests/test_polling_manager.py
@@ -1,13 +1,8 @@
-import json
-import multiprocessing
 import time
-from pathlib import Path
 from unittest import mock
 
-import pytest
 import requests
 import responses
-from pytest_httpserver import HTTPServer
 from pytest_mock import MockerFixture
 
 from flagsmith import Flagsmith
@@ -96,57 +91,3 @@ def test_polling_manager_is_resilient_to_request_exceptions(
     # Then
     assert polling_manager.is_alive()
     polling_manager.stop()
-
-
-@pytest.fixture
-def api_url(
-    httpserver: HTTPServer,
-    request: pytest.FixtureRequest,
-) -> str:
-    """A local HTTP server impersonating the Flagsmith environment-document API."""
-    body = (request.path.parent / "data/environment.json").read_bytes()
-    httpserver.expect_request("/api/v1/environment-document/").respond_with_data(
-        body, content_type="application/json"
-    )
-    return httpserver.url_for("/api/v1/")
-
-
-@pytest.mark.skipif(
-    "fork" not in multiprocessing.get_all_start_methods(),
-    reason="fork() is unavailable on this platform",
-)
-def test_polling_manager_keeps_polling_after_fork(api_url: str, tmp_path: Path) -> None:
-    # Given a flagsmith client polling against a local HTTP server.
-    flagsmith = Flagsmith(
-        environment_key="ser.dummy",
-        api_url=api_url,
-        enable_local_evaluation=True,
-        environment_refresh_interval_seconds=0.1,
-    )
-    parent_ident = flagsmith.environment_data_polling_manager_thread.ident
-
-    def _record_polling_state_in_child(flagsmith: Flagsmith, result_path: Path) -> None:
-        # Give the child a chance to poll.
-        time.sleep(0.1)
-        polling = flagsmith.environment_data_polling_manager_thread
-        result_path.write_text(
-            json.dumps({"is_alive": polling.is_alive(), "ident": polling.ident})
-        )
-
-    # Give the parent a chance to poll.
-    time.sleep(0.1)
-    result_path = tmp_path / "child_result.json"
-
-    # When the process forks (mimicking a gunicorn pre-fork worker).
-    proc = multiprocessing.get_context("fork").Process(
-        target=_record_polling_state_in_child, args=(flagsmith, result_path)
-    )
-    proc.start()
-    proc.join()
-
-    # Then the polling thread is alive in the child, and it's a fresh
-    # thread rather than the parent's (dead) one.
-    result = json.loads(result_path.read_text())
-    assert result["is_alive"], "polling thread did not survive fork()"
-    assert result["ident"] != parent_ident
-    flagsmith.environment_data_polling_manager_thread.stop()

--- a/tests/test_polling_manager_fork.py
+++ b/tests/test_polling_manager_fork.py
@@ -1,0 +1,67 @@
+import json
+import multiprocessing
+import time
+import typing
+from pathlib import Path
+
+import pytest
+
+# pytest-httpserver requires python>=3.10 — skip the whole module on
+# older interpreters where the dep isn't installed.
+pytest.importorskip("pytest_httpserver")
+
+from flagsmith import Flagsmith  # noqa: E402
+
+if typing.TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
+
+
+@pytest.fixture
+def api_url(httpserver: "HTTPServer", request: pytest.FixtureRequest) -> str:
+    """A local HTTP server impersonating the Flagsmith environment-document API."""
+    body = (request.path.parent / "data/environment.json").read_bytes()
+    httpserver.expect_request("/api/v1/environment-document/").respond_with_data(
+        body, content_type="application/json"
+    )
+    return httpserver.url_for("/api/v1/")
+
+
+@pytest.mark.skipif(
+    "fork" not in multiprocessing.get_all_start_methods(),
+    reason="fork() is unavailable on this platform",
+)
+def test_polling_manager_keeps_polling_after_fork(api_url: str, tmp_path: Path) -> None:
+    # Given a flagsmith client polling against a local HTTP server.
+    flagsmith = Flagsmith(
+        environment_key="ser.dummy",
+        api_url=api_url,
+        enable_local_evaluation=True,
+        environment_refresh_interval_seconds=0.1,
+    )
+    parent_ident = flagsmith.environment_data_polling_manager_thread.ident
+
+    def _record_polling_state_in_child(flagsmith: Flagsmith, result_path: Path) -> None:
+        # Give the child a chance to poll.
+        time.sleep(0.1)
+        polling = flagsmith.environment_data_polling_manager_thread
+        result_path.write_text(
+            json.dumps({"is_alive": polling.is_alive(), "ident": polling.ident})
+        )
+
+    # Give the parent a chance to poll.
+    time.sleep(0.1)
+    result_path = tmp_path / "child_result.json"
+
+    # When the process forks (mimicking a gunicorn pre-fork worker).
+    proc = multiprocessing.get_context("fork").Process(
+        target=_record_polling_state_in_child, args=(flagsmith, result_path)
+    )
+    proc.start()
+    proc.join()
+
+    # Then the polling thread is alive in the child, and it's a fresh
+    # thread rather than the parent's (dead) one.
+    result = json.loads(result_path.read_text())
+    assert result["is_alive"], "polling thread did not survive fork()"
+    assert result["ident"] != parent_ident
+    flagsmith.environment_data_polling_manager_thread.stop()


### PR DESCRIPTION

Closes #77.

The polling thread that refreshes the local evaluation environment document is created in the parent process. Threads do not survive `os.fork()`, so pre-fork servers (gunicorn, uwsgi, multiprocessing) end up with worker processes whose Python `Thread` object is intact but whose underlying OS thread is dead. `is_alive()` correctly reports `False`, no polls happen, and workers serve a frozen environment-document snapshot from the moment of fork for their entire lifetime.

`EnvironmentDataPollingManager` now composes a `threading.Thread` instead of inheriting from it, and registers an `os.register_at_fork(after_in_child=...)` hook so a fresh polling thread is started in each child. The hook also closes the parent's `requests.Session` because connection-pool sockets are inherited as shared FDs across fork; reusing them would interleave bytes between processes.

## Notes

- The same problem applies to the SSE event stream thread and the analytics processor thread. Perhaps we need a better approach than simply multiplying threads.

## Test plan

- [x] New regression test `test_polling_manager_keeps_polling_after_fork` spawns a `multiprocessing.get_context("fork").Process`, asserts `is_alive=True` in the child, and asserts the child's `ident` differs from the parent's (i.e. it is a fresh thread, not the dead inherited one).
- [x] All existing tests pass (95/95).
- [x] mypy clean.

## Notes

- pytest-httpserver added as a dev dependency for the new test fixture.