### PR TITLE
ci: disable github-actions manager in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
     "semanticCommitType": "deps",
     "packageRules": [
         {
-            "matchManagers": ["pip_requirements", "pip-compile", "pep621", "poetry"],
+            "matchManagers": ["pip_requirements", "pip-compile", "pep621", "poetry", "github-actions"],
             "matchUpdateTypes": [
                 "major",
                 "minor",


### PR DESCRIPTION
## Summary
- Adds `github-actions` to the existing manager-disable rule in `renovate.json`, alongside the Python managers.
- Same shape as before: `matchUpdateTypes` deliberately omits `vulnerabilityAlerts`, so CVE PRs still flow through for both Python deps and Action references.
- Net effect: no more routine `actions/*@vN` or runner-image bump PRs; CVE coverage retained; `flagsmith-flag-engine` carve-out unchanged.

## Test plan
- [x] Renovate dashboard issue refreshes without scheduling routine `github-actions` bumps for `uses:` lines in `.github/workflows/*.yml`.
- [x] Confirm Dependabot security updates remain enabled at the repo level so the CVE path stays redundant-by-design.