### PR TITLE
fix: Background threads leaking across tests

### DIFF
--- a/flagsmith/polling_manager.py
+++ b/flagsmith/polling_manager.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import threading
-import time
 import typing
 
 if typing.TYPE_CHECKING:
@@ -25,9 +24,16 @@ class EnvironmentDataPollingManager(threading.Thread):
         self.refresh_interval_seconds = refresh_interval_seconds
 
     def run(self) -> None:
+        # Wait on the stop event rather than sleeping so stop() interrupts
+        # the interval immediately and the thread can be joined promptly.
         while not self._stop_event.is_set():
-            self.main.update_environment()
-            time.sleep(self.refresh_interval_seconds)
+            try:
+                self.main.update_environment()
+            except Exception:
+                # Never let an unexpected error kill the polling thread; log
+                # it and try again on the next interval.
+                logger.exception("Error updating environment")
+            self._stop_event.wait(self.refresh_interval_seconds)
 
     def stop(self) -> None:
         self._stop_event.set()

--- a/flagsmith/polling_manager.py
+++ b/flagsmith/polling_manager.py
@@ -24,14 +24,10 @@ class EnvironmentDataPollingManager(threading.Thread):
         self.refresh_interval_seconds = refresh_interval_seconds
 
     def run(self) -> None:
-        # Wait on the stop event rather than sleeping so stop() interrupts
-        # the interval immediately and the thread can be joined promptly.
         while not self._stop_event.is_set():
             try:
                 self.main.update_environment()
             except Exception:
-                # Never let an unexpected error kill the polling thread; log
-                # it and try again on the next interval.
                 logger.exception("Error updating environment")
             self._stop_event.wait(self.refresh_interval_seconds)
 

--- a/flagsmith/streaming_manager.py
+++ b/flagsmith/streaming_manager.py
@@ -40,7 +40,9 @@ class EventStreamManager(threading.Thread):
                     for event in sse_client.events():
                         self.on_event(map_sse_event_to_stream_event(event))
 
-            except (requests.RequestException, ValueError, TypeError):
+            except Exception:
+                # Never let an unexpected error kill the stream thread; log it
+                # and reconnect on the next loop iteration.
                 logger.exception("Error opening or reading from the event stream")
 
     def stop(self) -> None:

--- a/flagsmith/streaming_manager.py
+++ b/flagsmith/streaming_manager.py
@@ -42,6 +42,7 @@ class EventStreamManager(threading.Thread):
 
             except Exception:
                 logger.exception("Error opening or reading from the event stream")
+                self._stop_event.wait(1)
 
     def stop(self) -> None:
         self._stop_event.set()

--- a/flagsmith/streaming_manager.py
+++ b/flagsmith/streaming_manager.py
@@ -41,8 +41,6 @@ class EventStreamManager(threading.Thread):
                         self.on_event(map_sse_event_to_stream_event(event))
 
             except Exception:
-                # Never let an unexpected error kill the stream thread; log it
-                # and reconnect on the next loop iteration.
                 logger.exception("Error opening or reading from the event stream")
 
     def stop(self) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,11 +40,18 @@ def stop_flagsmith_background_threads(
 
     monkeypatch.setattr(Flagsmith, "__init__", tracking_init)
     yield
+    # Join, not just stop: pyfakefs is not thread-safe, so a thread that is
+    # still winding down races with the filesystem patching the next test
+    # performs (and, under pytest>=8.1, surfaces as a thread-exception error).
     for flagsmith in instances:
-        if getattr(flagsmith, "environment_data_polling_manager_thread", None):
-            flagsmith.environment_data_polling_manager_thread.stop()
-        if getattr(flagsmith, "event_stream_thread", None):
-            flagsmith.event_stream_thread.stop()
+        if polling := getattr(
+            flagsmith, "environment_data_polling_manager_thread", None
+        ):
+            polling.stop()
+            polling.join(timeout=5)
+        if stream := getattr(flagsmith, "event_stream_thread", None):
+            stream.stop()
+            stream.join(timeout=5)
         if flagsmith._event_processor:
             flagsmith._event_processor.stop()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,9 +40,6 @@ def stop_flagsmith_background_threads(
 
     monkeypatch.setattr(Flagsmith, "__init__", tracking_init)
     yield
-    # Join, not just stop: pyfakefs is not thread-safe, so a thread that is
-    # still winding down races with the filesystem patching the next test
-    # performs (and, under pytest>=8.1, surfaces as a thread-exception error).
     for flagsmith in instances:
         if polling := getattr(
             flagsmith, "environment_data_polling_manager_thread", None

--- a/tests/test_flagsmith.py
+++ b/tests/test_flagsmith.py
@@ -795,8 +795,15 @@ def test_stream_not_used_by_default(
 
 
 def test_stream_used_when_enable_realtime_updates_is_true(
-    requests_session_response_ok: None, server_api_key: str
+    requests_session_response_ok: None, server_api_key: str, mocker: MockerFixture
 ) -> None:
+    # Given
+    # Keep the stream worker off the network so it stays idle until torn down.
+    mocker.patch(
+        "flagsmith.streaming_manager.requests.get",
+        side_effect=requests.exceptions.ReadTimeout(),
+    )
+
     # When
     flagsmith = Flagsmith(
         environment_key=server_api_key,

--- a/tests/test_flagsmith.py
+++ b/tests/test_flagsmith.py
@@ -798,7 +798,6 @@ def test_stream_used_when_enable_realtime_updates_is_true(
     requests_session_response_ok: None, server_api_key: str, mocker: MockerFixture
 ) -> None:
     # Given
-    # Keep the stream worker off the network so it stays idle until torn down.
     mocker.patch(
         "flagsmith.streaming_manager.requests.get",
         side_effect=requests.exceptions.ReadTimeout(),


### PR DESCRIPTION

Background worker threads could outlive the test that created them, then race with pyfakefs in a later test. This never surfaced until #228 because pytest 9 turns the resulting unhandled thread exceptions into test errors.

The changes here are version-agnostic and pass on both pytest 7.4.4 (current main) and pytest 9.0.3.

Testing:

- Reproduced both failures deterministically against pytest 9.0.3 / pyfakefs 5.10.2, and confirmed they disappear with these changes (suite run repeatedly, including under `-W error`).
- Full suite green on Python 3.10, 3.12 and 3.13.
